### PR TITLE
[33] - Updated  outputPath in angular.json

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -13,7 +13,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": "dist/hwc-inventory-ui-next",
+            "outputPath": "dist/",
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": [


### PR DESCRIPTION
Updated outputPath in angular.json to fix the Forbidden error during wildfly deployment.