### PR TITLE
fix: prevent user logout on sub store indent receive error

### DIFF
--- a/src/app/app-modules/core/services/http-interceptor.service.ts
+++ b/src/app/app-modules/core/services/http-interceptor.service.ts
@@ -81,15 +81,13 @@ export class HttpInterceptorService implements HttpInterceptor {
 
         if (error.status === 401 || error.status === 403) {
           this.confirmationService.alert(
-            "Session expired. Please log in again to continue", 'error'
+            'Session expired. Please log in again to continue',
+            'error',
           );
-        } else this.confirmationService.alert(
-          error.error.errorMessage || "Something went wrong. Please try again later.",
-          'error',
-        );
-        this.router.navigate(['/login']);
-        sessionStorage.clear();
-        localStorage.clear();
+          this.router.navigate(['/login']);
+          sessionStorage.clear();
+          localStorage.clear();
+        }
         this.spinnerService.show();
         return throwError(error.error);
       }),

--- a/src/app/app-modules/inventory/indent/indent-order-worklist/sub-store-indent-order-worklist/sub-store-indent-order-worklist.component.ts
+++ b/src/app/app-modules/inventory/indent/indent-order-worklist/sub-store-indent-order-worklist/sub-store-indent-order-worklist.component.ts
@@ -114,17 +114,25 @@ export class SubStoreIndentOrderWorklistComponent implements OnInit, DoCheck {
     console.log('acceptorder', acceptorder);
     this.inventoryService
       .receiveIndentOrder(acceptorder)
-      .subscribe((acceptOrderResponse) => {
-        if (acceptOrderResponse.statusCode === 200) {
+      .subscribe(
+        (acceptOrderResponse) => {
+          if (acceptOrderResponse.statusCode === 200) {
+            this.confirmationService.alert(
+              acceptOrderResponse.data.response,
+              'success',
+            );
+            this.showSubstoreOrderWorklist(this.orderReqObject);
+          } else {
+            this.confirmationService.alert(acceptOrderResponse.errorMessage);
+          }
+        },
+        (error) => {
+          console.error('Error receiving indent', error);
           this.confirmationService.alert(
-            acceptOrderResponse.data.response,
-            'success',
+            error?.errorMessage || this.currentLanguageSet?.inventory?.receiveIndentFailed || 'Failed to receive indent. Please try again.',
           );
-          this.showSubstoreOrderWorklist(this.orderReqObject);
-        } else {
-          this.confirmationService.alert(acceptOrderResponse.errorMessage);
-        }
-      });
+        },
+      );
   }
   goToUpdateIndentRequest(indentDetails: any) {
     console.log('indentDetails', indentDetails);

--- a/src/environments/environment.ci.ts.template
+++ b/src/environments/environment.ci.ts.template
@@ -115,7 +115,7 @@ export const environment = {
   viewItemListForMainStoreUrl: `${INVENTORY_API}indentController/getIndentOrderWorklist`,
 
   getSaveDispenseListUrl: `${INVENTORY_API}indentController/issueIndent`,
-  receiveIndentOrderUrl: `${INVENTORY_API}/indentController/receiveIndent`,
+  receiveIndentOrderUrl: `${INVENTORY_API}indentController/receiveIndent`,
   updateIndentOrderUrl: `${INVENTORY_API}indentController/updateIndentOrder`,
 
   /* Report URL's*/

--- a/src/environments/environment.local.ts
+++ b/src/environments/environment.local.ts
@@ -124,7 +124,7 @@ export const environment = {
   viewItemListForMainStoreUrl: `${INVENTORY_API}indentController/getIndentOrderWorklist`,
 
   getSaveDispenseListUrl: `${INVENTORY_API}indentController/issueIndent`,
-  receiveIndentOrderUrl: `${INVENTORY_API}/indentController/receiveIndent`,
+  receiveIndentOrderUrl: `${INVENTORY_API}indentController/receiveIndent`,
   updateIndentOrderUrl: `${INVENTORY_API}indentController/updateIndentOrder`,
 
   /* Report URL's*/

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -125,7 +125,7 @@ export const environment = {
   viewItemListForMainStoreUrl: `${INVENTORY_API}indentController/getIndentOrderWorklist`,
 
   getSaveDispenseListUrl: `${INVENTORY_API}indentController/issueIndent`,
-  receiveIndentOrderUrl: `${INVENTORY_API}/indentController/receiveIndent`,
+  receiveIndentOrderUrl: `${INVENTORY_API}indentController/receiveIndent`,
   updateIndentOrderUrl: `${INVENTORY_API}indentController/updateIndentOrder`,
 
   /* Report URL's*/

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -119,7 +119,7 @@ export const environment = {
   viewItemListForMainStoreUrl: `${INVENTORY_API}indentController/getIndentOrderWorklist`,
 
   getSaveDispenseListUrl: `${INVENTORY_API}indentController/issueIndent`,
-  receiveIndentOrderUrl: `${INVENTORY_API}/indentController/receiveIndent`,
+  receiveIndentOrderUrl: `${INVENTORY_API}indentController/receiveIndent`,
   updateIndentOrderUrl: `${INVENTORY_API}indentController/updateIndentOrder`,
 
   /* Report URL's*/


### PR DESCRIPTION
## 📋 Description

JIRA ID: 

AMM-2133
---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)

---

## ℹ️ Additional Information

Stop the HTTP interceptor from clearing session and redirecting to login on non-authentication errors. Only 401/403 errors now trigger logout. 
Added error handling in the receiveIndent subscribe to show a single user-friendly error message.
Removed extra / from the API URL- receiveIndentOrderUrl
